### PR TITLE
[Bugfix] fix integer overflow for a large png files.

### DIFF
--- a/src/PdfToSvg/Imaging/Png/PngEncoder.cs
+++ b/src/PdfToSvg/Imaging/Png/PngEncoder.cs
@@ -46,7 +46,7 @@ namespace PdfToSvg.Imaging.Png
                 _ => 1,
             };
 
-            estimatedSize = width * height * componentsPerSample * bitDepth / 50;
+            estimatedSize = (int)((long)width * height * componentsPerSample * bitDepth / 50);
 
             using (var chunk = new PngChunkStream(output, PngChunkIdentifier.ImageHeader))
             {


### PR DESCRIPTION
Just a tiny bugfix for a large png's.
Here is a test file.

[pvc_planen_oesen_200x100_2.pdf](https://github.com/user-attachments/files/21198888/pvc_planen_oesen_200x100_2.pdf)
