### PR TITLE
[Bugfix] ArgumentOutOfRange in InlineImageHelper.DetectStreamLength

### DIFF
--- a/src/PdfToSvg/Parsing/InlineImageHelper.cs
+++ b/src/PdfToSvg/Parsing/InlineImageHelper.cs
@@ -58,7 +58,7 @@ namespace PdfToSvg.Parsing
             // Prefer deterministic stream length detectors
             var outerFilterName =
                 filterNames is PdfName singleFilterName ? singleFilterName :
-                filterNames is object?[] filterNamesArray ? filterNamesArray[0] as PdfName :
+                filterNames is object?[] filterNamesArray && filterNamesArray.Length > 0 ? filterNamesArray[0] as PdfName :
                 null;
 
             var outerFilter = Filter.ByName(outerFilterName);

--- a/tests/PdfToSvg.Tests/Parsing/InlineImageHelperTests.cs
+++ b/tests/PdfToSvg.Tests/Parsing/InlineImageHelperTests.cs
@@ -57,6 +57,13 @@ namespace PdfToSvg.Tests.Parsing
             var stream = new MemoryStream(Encoding.ASCII.GetBytes("fjg\0h EI EI EI dk\0djgk \r ~> end of stream"));
             Assert.AreEqual(27, InlineImageHelper.DetectStreamLength(stream, new object[] { Names.ASCII85Decode, Names.FlateDecode }));
         }
+        
+        [Test]
+        public void DoNotCrashIfFilterIsEmptyArray()
+        {
+            var stream = new MemoryStream(Encoding.ASCII.GetBytes("fjg\0h EI EI EI dk\0djgk \r ~> end of stream"));
+            Assert.AreEqual(27, InlineImageHelper.DetectStreamLength(stream, new object[0]));
+        }
 
         [Test]
         public void DeabbreviateDictionary()


### PR DESCRIPTION
Test file: 
[Logo-DestarGuideLineFINAL.pdf](https://github.com/user-attachments/files/21211764/Logo-DestarGuideLineFINAL.pdf)
